### PR TITLE
Add summary markdown as action output

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The `forcedotcom/run-code-analyzer@v2` GitHub Action is based on [Salesforce Cod
   * The number of Low (4) severity violations found.
 * `num-sev5-violations`
   * The number of Info (5) severity violations found.
+* `summary-markdown`
+  * Summary table in markdown format of violations found.
 
 This `run-code-analyzer@v2` action won't exit your GitHub workflow when it finds violations. We recommend that you add a subsequent step to your workflow that uses the available outputs to determine how your workflow should proceed.
 
@@ -52,7 +54,9 @@ The [Salesforce Code Analyzer v5.x (Beta)](https://developer.salesforce.com/docs
 ## Example v2 Usage
 
     name: Salesforce Code Analyzer Workflow
-    on: push
+    on:
+      pull_request:
+        types: [opened]
     jobs:
       salesforce-code-analyzer-workflow:
         runs-on: ubuntu-latest
@@ -88,6 +92,18 @@ The [Salesforce Code Analyzer v5.x (Beta)](https://developer.salesforce.com/docs
               run-arguments: --workspace . --view detail --output-file sfca_results.html --output-file sfca_results.json
               results-artifact-name: salesforce-code-analyzer-results
     
+          - name: Upload Salesforce Code Analyzer results as PR comment
+            uses: actions/github-script@v7
+            with:
+              github-token: ${{ secrets.GITHUB_TOKEN }}
+              script: |
+                github.rest.issues.createComment({
+                  issue_number: '${{ github.event.number }}',
+                  owner: '${{ github.event.repository.owner.login }}',
+                  repo: '${{ github.event.repository.name }}',
+                  body: `${{ steps.run-code-analyzer.outputs.summary-markdown }}`
+                });
+
           - name: Check the outputs to determine whether to fail
             if: |
               steps.run-code-analyzer.outputs.exit-code > 0 ||

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -37,7 +37,7 @@ describe('main run Tests', () => {
             resultsFile: 'sfca_results.json'
         })
 
-        expect(dependencies.setOutputCallHistory).toHaveLength(7)
+        expect(dependencies.setOutputCallHistory).toHaveLength(8)
         expect(dependencies.setOutputCallHistory).toContainEqual({
             name: 'exit-code',
             value: '0'
@@ -66,6 +66,10 @@ describe('main run Tests', () => {
             name: 'num-sev5-violations',
             value: '5'
         })
+        expect(dependencies.setOutputCallHistory).toContainEqual({
+            name: 'summary-markdown',
+            value: 'someSummaryMarkdown'
+        })
 
         expect(dependencies.infoCallHistory).toContainEqual({
             infoMessage:
@@ -76,7 +80,8 @@ describe('main run Tests', () => {
                 '  num-sev2-violations: 2\n' +
                 '  num-sev3-violations: 3\n' +
                 '  num-sev4-violations: 4\n' +
-                '  num-sev5-violations: 5'
+                '  num-sev5-violations: 5\n' +
+                '  summary-markdown: someSummaryMarkdown'
         })
 
         expect(summarizer.createSummaryMarkdownCallHistory).toHaveLength(1)

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,8 @@ outputs:
     description: The number of Low (4) severity violations found.
   num-sev5-violations:
     description: The number of Info (5) severity violations found.
+  summary-markdown:
+    description: Summary table in markdown format of violations found.
 
 runs:
   using: node20

--- a/src/main.ts
+++ b/src/main.ts
@@ -67,6 +67,12 @@ export async function run(
         dependencies.setOutput('num-sev3-violations', results.getSev3ViolationCount().toString())
         dependencies.setOutput('num-sev4-violations', results.getSev4ViolationCount().toString())
         dependencies.setOutput('num-sev5-violations', results.getSev5ViolationCount().toString())
+        dependencies.endGroup()
+
+        dependencies.startGroup(MESSAGES.STEP_LABELS.CREATING_SUMMARY)
+        const summaryMarkdown: string = summarizer.createSummaryMarkdown(results)
+        dependencies.setOutput('summary-markdown', summaryMarkdown)
+        await dependencies.writeSummary(summaryMarkdown)
         dependencies.info(
             `outputs:\n` +
                 `  exit-code: ${codeAnalyzerOutput.exitCode}\n` +
@@ -75,13 +81,9 @@ export async function run(
                 `  num-sev2-violations: ${results.getSev2ViolationCount()}\n` +
                 `  num-sev3-violations: ${results.getSev3ViolationCount()}\n` +
                 `  num-sev4-violations: ${results.getSev4ViolationCount()}\n` +
-                `  num-sev5-violations: ${results.getSev5ViolationCount()}`
+                `  num-sev5-violations: ${results.getSev5ViolationCount()}\n` +
+                `  summary-markdown: ${summaryMarkdown}`
         )
-        dependencies.endGroup()
-
-        dependencies.startGroup(MESSAGES.STEP_LABELS.CREATING_SUMMARY)
-        const summaryMarkdown: string = summarizer.createSummaryMarkdown(results)
-        await dependencies.writeSummary(summaryMarkdown)
         dependencies.endGroup()
     } catch (error) {
         if (error instanceof Error) {


### PR DESCRIPTION
Closes #55 submitted by @sameerseekala1

Like @stephen-carter-at-sf - I agreed this would be a great enhancement to the action so I added the markdown table generated as a job summary as an action output that could then be referenced in a future step. I updated the README to show how the github-script action can leverage the output to post a PR comment.