### PR TITLE
fix: [BUG][github-action] GitHub Enterprise | Incorrect bot comment url (#2052)

### DIFF
--- a/__tests__/dependencies.test.ts
+++ b/__tests__/dependencies.test.ts
@@ -20,7 +20,8 @@ jest.mock('@actions/github', () => ({
         },
         runId: 12345,
         runAttempt: 1,
-        job: 'test-job'
+        job: 'test-job',
+        serverUrl: 'https://github.com'
     },
     getOctokit: jest.fn()
 }))
@@ -302,6 +303,54 @@ describe('RuntimeDependencies Code Coverage', () => {
         const result = await dependencies.createActionSummaryLink('test-token')
 
         expect(result).toEqual('https://github.com/test-owner/test-repo/actions/runs/12345/attempts/1')
+    })
+
+    it('createActionSummaryLink - uses serverUrl for GitHub Enterprise Server', async () => {
+        const originalServerUrl = github.context.serverUrl
+        ;(github.context as { serverUrl: string }).serverUrl = 'https://github.securian.com'
+
+        const mockOctokit = {
+            rest: {
+                actions: {
+                    listJobsForWorkflowRun: jest.fn().mockResolvedValue({
+                        data: {
+                            jobs: [{ id: 5, name: 'test-job' }]
+                        }
+                    })
+                }
+            }
+        }
+        ;(github.getOctokit as jest.Mock).mockReturnValue(mockOctokit)
+
+        const result = await dependencies.createActionSummaryLink('test-token')
+
+        expect(result).toEqual(
+            'https://github.securian.com/test-owner/test-repo/actions/runs/12345/attempts/1#summary-5'
+        )
+        ;(github.context as { serverUrl: string }).serverUrl = originalServerUrl
+    })
+
+    it('createActionSummaryLink - uses serverUrl for GHES without matching job', async () => {
+        const originalServerUrl = github.context.serverUrl
+        ;(github.context as { serverUrl: string }).serverUrl = 'https://github.securian.com'
+
+        const mockOctokit = {
+            rest: {
+                actions: {
+                    listJobsForWorkflowRun: jest.fn().mockResolvedValue({
+                        data: {
+                            jobs: [{ id: 1, name: 'other-job' }]
+                        }
+                    })
+                }
+            }
+        }
+        ;(github.getOctokit as jest.Mock).mockReturnValue(mockOctokit)
+
+        const result = await dependencies.createActionSummaryLink('test-token')
+
+        expect(result).toEqual('https://github.securian.com/test-owner/test-repo/actions/runs/12345/attempts/1')
+        ;(github.context as { serverUrl: string }).serverUrl = originalServerUrl
     })
 
     it('createActionSummaryLink - API error', async () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -106132,6 +106132,7 @@ class RuntimeDependencies {
         const repo = github.context.repo.repo;
         const runId = github.context.runId;
         const runAttempt = github.context.runAttempt;
+        const serverUrl = github.context.serverUrl;
         const octokit = github.getOctokit(githubToken);
         let matchingJob;
         try {
@@ -106153,10 +106154,10 @@ class RuntimeDependencies {
         // matrices, then we can't link directly to the table, and have to link to just the page itself and expect the user]
         // to scroll down the table themselves.
         if (matchingJob) {
-            return `https://github.com/${owner}/${repo}/actions/runs/${runId}/attempts/${runAttempt}#summary-${matchingJob.id}`;
+            return `${serverUrl}/${owner}/${repo}/actions/runs/${runId}/attempts/${runAttempt}#summary-${matchingJob.id}`;
         }
         else {
-            return `https://github.com/${owner}/${repo}/actions/runs/${runId}/attempts/${runAttempt}`;
+            return `${serverUrl}/${owner}/${repo}/actions/runs/${runId}/attempts/${runAttempt}`;
         }
     }
     async createPullRequestReview(githubToken, reviewBody) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "typescript-eslint": "^8.59.4"
             },
             "engines": {
-                "node": ">=20.9.0"
+                "node": ">=24.0.0"
             }
         },
         "node_modules/@actions/artifact": {

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -108,6 +108,7 @@ export class RuntimeDependencies implements Dependencies {
         const repo = github.context.repo.repo
         const runId = github.context.runId
         const runAttempt = github.context.runAttempt
+        const serverUrl = github.context.serverUrl
         const octokit = github.getOctokit(githubToken)
         let matchingJob: { id: number } | undefined
         try {
@@ -128,9 +129,9 @@ export class RuntimeDependencies implements Dependencies {
         // matrices, then we can't link directly to the table, and have to link to just the page itself and expect the user]
         // to scroll down the table themselves.
         if (matchingJob) {
-            return `https://github.com/${owner}/${repo}/actions/runs/${runId}/attempts/${runAttempt}#summary-${matchingJob.id}`
+            return `${serverUrl}/${owner}/${repo}/actions/runs/${runId}/attempts/${runAttempt}#summary-${matchingJob.id}`
         } else {
-            return `https://github.com/${owner}/${repo}/actions/runs/${runId}/attempts/${runAttempt}`
+            return `${serverUrl}/${owner}/${repo}/actions/runs/${runId}/attempts/${runAttempt}`
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes forcedotcom/code-analyzer#2052

## Root Cause
In src/dependencies.ts lines 131-133, the createActionSummaryLink method hardcodes 'https://github.com/' as the URL prefix when constructing the job summary link for the PR review comment. On GitHub Enterprise Server instances, the server URL is different (e.g. https://github.securian.com). The @actions/github package already provides github.context.serverUrl which reads from the GITHUB_SERVER_URL environment variable (set by GitHub Actions runtime to the correct server URL), but the code doesn't use it. The fix is to replace the hardcoded 'https://github.com' with github.context.serverUrl in both URL template literals.

## Fix
Replaced hardcoded https://github.com with github.context.serverUrl in createActionSummaryLink to support GitHub Enterprise Server instances

## Testing
- ✅ Unit tests added/updated
- ✅ All tests passing
- ✅ Lint checks passing

## Functional Testing Evidence
Tested on Dreamhouse project:
- Test 1: GitHub Action integration with fix/issue-2052-ghes-server-url branch - PASS; Workflow executed successfully (https://github.com/nikhil-mittal-165/apex-test/actions/runs/28152934495); Build completed with success conclusion; Code-Analyzer action ran and scanned apex-test repo (36 violations found - 12 High, 1 Moderate, 23 Low)
- Test 2: Source code fix verification - PASS; src/dependencies.ts lines 132 and 134 use serverUrl variable instead of hardcoded https://github.com/
- Test 3: Compiled distribution verification - PASS; Built dist/index.js contains correct serverUrl usage in URL template literals

Overall Status: PASS ✅