### PR TITLE
CHANGE @W-22462041@ Update Node dependencies (minor/patch versions)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -76011,6 +76011,11 @@ const parseComparator = (comp, options) => {
 
 const isX = id => !id || id.toLowerCase() === 'x' || id === '*'
 
+const invalidXRangeOrder = (M, m, p) => (
+  (isX(M) && !isX(m)) ||
+  (isX(m) && p && !isX(p))
+)
+
 // ~, ~> --> * (any, kinda silly)
 // ~2, ~2.x, ~2.x.x, ~>2, ~>2.x ~>2.x.x --> >=2.0.0 <3.0.0-0
 // ~2.0, ~2.0.x, ~>2.0, ~>2.0.x --> >=2.0.0 <2.1.0-0
@@ -76028,6 +76033,10 @@ const replaceTildes = (comp, options) => {
 
 const replaceTilde = (comp, options) => {
   const r = options.loose ? re[t.TILDELOOSE] : re[t.TILDE]
+  // if we're including prereleases in the match, then the lower bound is
+  // -0, the lowest possible prerelease value, just like x-ranges and carets.
+  // this keeps `~1.2` equivalent to the `1.2.x` x-range it's documented as.
+  const z = options.includePrerelease ? '-0' : ''
   return comp.replace(r, (_, M, m, p, pr) => {
     debug('tilde', comp, _, M, m, p, pr)
     let ret
@@ -76035,10 +76044,10 @@ const replaceTilde = (comp, options) => {
     if (isX(M)) {
       ret = ''
     } else if (isX(m)) {
-      ret = `>=${M}.0.0 <${+M + 1}.0.0-0`
+      ret = `>=${M}.0.0${z} <${+M + 1}.0.0-0`
     } else if (isX(p)) {
       // ~1.2 == >=1.2.0 <1.3.0-0
-      ret = `>=${M}.${m}.0 <${M}.${+m + 1}.0-0`
+      ret = `>=${M}.${m}.0${z} <${M}.${+m + 1}.0-0`
     } else if (pr) {
       debug('replaceTilde pr', pr)
       ret = `>=${M}.${m}.${p}-${pr
@@ -76107,10 +76116,10 @@ const replaceCaret = (comp, options) => {
       if (M === '0') {
         if (m === '0') {
           ret = `>=${M}.${m}.${p
-          }${z} <${M}.${m}.${+p + 1}-0`
+          } <${M}.${m}.${+p + 1}-0`
         } else {
           ret = `>=${M}.${m}.${p
-          }${z} <${M}.${+m + 1}.0-0`
+          } <${M}.${+m + 1}.0-0`
         }
       } else {
         ret = `>=${M}.${m}.${p
@@ -76136,6 +76145,10 @@ const replaceXRange = (comp, options) => {
   const r = options.loose ? re[t.XRANGELOOSE] : re[t.XRANGE]
   return comp.replace(r, (ret, gtlt, M, m, p, pr) => {
     debug('xRange', comp, ret, gtlt, M, m, p, pr)
+    if (invalidXRangeOrder(M, m, p)) {
+      return comp
+    }
+
     const xM = isX(M)
     const xm = xM || isX(m)
     const xp = xm || isX(p)
@@ -76312,6 +76325,22 @@ const { safeRe: re, t } = __nccwpck_require__(95471)
 
 const parseOptions = __nccwpck_require__(70356)
 const { compareIdentifiers } = __nccwpck_require__(73348)
+
+const isPrereleaseIdentifier = (prerelease, identifier) => {
+  const identifiers = identifier.split('.')
+  if (identifiers.length > prerelease.length) {
+    return false
+  }
+
+  for (let i = 0; i < identifiers.length; i++) {
+    if (compareIdentifiers(prerelease[i], identifiers[i]) !== 0) {
+      return false
+    }
+  }
+
+  return true
+}
+
 class SemVer {
   constructor (version, options) {
     options = parseOptions(options)
@@ -76615,8 +76644,9 @@ class SemVer {
           if (identifierBase === false) {
             prerelease = [identifier]
           }
-          if (compareIdentifiers(this.prerelease[0], identifier) === 0) {
-            if (isNaN(this.prerelease[1])) {
+          if (isPrereleaseIdentifier(this.prerelease, identifier)) {
+            const prereleaseBase = this.prerelease[identifier.split('.').length]
+            if (isNaN(prereleaseBase)) {
               this.prerelease = prerelease
             }
           } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@actions/core": "^2.0.3",
                 "@actions/exec": "^2.0.0",
                 "@actions/github": "^6.0.1",
-                "semver": "^7.8.1"
+                "semver": "^7.8.5"
             },
             "devDependencies": {
                 "@eslint/js": "^9.39.4",
@@ -25,15 +25,15 @@
                 "eslint-plugin-github": "^6.0.0",
                 "eslint-plugin-jest": "^29.15.2",
                 "eslint-plugin-jsonc": "^2.21.1",
-                "eslint-plugin-prettier": "^5.5.5",
+                "eslint-plugin-prettier": "^5.5.6",
                 "globals": "^16.5.0",
                 "jest": "^30.4.2",
                 "make-coverage-badge": "^1.2.0",
-                "prettier": "^3.8.3",
+                "prettier": "^3.8.4",
                 "prettier-eslint": "^16.4.2",
                 "ts-jest": "^29.4.11",
                 "typescript": "^5.9.3",
-                "typescript-eslint": "^8.59.4"
+                "typescript-eslint": "^8.61.1"
             },
             "engines": {
                 "node": ">=24.0.0"
@@ -1966,13 +1966,13 @@
             }
         },
         "node_modules/@pkgr/core": {
-            "version": "0.2.9",
-            "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-            "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+            "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+                "node": "^14.18.0 || >=16.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/pkgr"
@@ -2224,17 +2224,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.4.tgz",
-            "integrity": "sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
+            "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.59.4",
-                "@typescript-eslint/type-utils": "8.59.4",
-                "@typescript-eslint/utils": "8.59.4",
-                "@typescript-eslint/visitor-keys": "8.59.4",
+                "@typescript-eslint/scope-manager": "8.62.0",
+                "@typescript-eslint/type-utils": "8.62.0",
+                "@typescript-eslint/utils": "8.62.0",
+                "@typescript-eslint/visitor-keys": "8.62.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -2247,7 +2247,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.59.4",
+                "@typescript-eslint/parser": "^8.62.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
@@ -2263,16 +2263,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.4.tgz",
-            "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
+            "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.59.4",
-                "@typescript-eslint/types": "8.59.4",
-                "@typescript-eslint/typescript-estree": "8.59.4",
-                "@typescript-eslint/visitor-keys": "8.59.4",
+                "@typescript-eslint/scope-manager": "8.62.0",
+                "@typescript-eslint/types": "8.62.0",
+                "@typescript-eslint/typescript-estree": "8.62.0",
+                "@typescript-eslint/visitor-keys": "8.62.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -2288,14 +2288,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.4.tgz",
-            "integrity": "sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
+            "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.59.4",
-                "@typescript-eslint/types": "^8.59.4",
+                "@typescript-eslint/tsconfig-utils": "^8.62.0",
+                "@typescript-eslint/types": "^8.62.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -2310,14 +2310,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.4.tgz",
-            "integrity": "sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
+            "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.4",
-                "@typescript-eslint/visitor-keys": "8.59.4"
+                "@typescript-eslint/types": "8.62.0",
+                "@typescript-eslint/visitor-keys": "8.62.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2328,9 +2328,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.4.tgz",
-            "integrity": "sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
+            "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2345,15 +2345,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.4.tgz",
-            "integrity": "sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
+            "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.4",
-                "@typescript-eslint/typescript-estree": "8.59.4",
-                "@typescript-eslint/utils": "8.59.4",
+                "@typescript-eslint/types": "8.62.0",
+                "@typescript-eslint/typescript-estree": "8.62.0",
+                "@typescript-eslint/utils": "8.62.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -2370,9 +2370,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.4.tgz",
-            "integrity": "sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+            "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2384,16 +2384,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.4.tgz",
-            "integrity": "sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
+            "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.59.4",
-                "@typescript-eslint/tsconfig-utils": "8.59.4",
-                "@typescript-eslint/types": "8.59.4",
-                "@typescript-eslint/visitor-keys": "8.59.4",
+                "@typescript-eslint/project-service": "8.62.0",
+                "@typescript-eslint/tsconfig-utils": "8.62.0",
+                "@typescript-eslint/types": "8.62.0",
+                "@typescript-eslint/visitor-keys": "8.62.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -2422,9 +2422,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2451,16 +2451,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.4.tgz",
-            "integrity": "sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+            "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.59.4",
-                "@typescript-eslint/types": "8.59.4",
-                "@typescript-eslint/typescript-estree": "8.59.4"
+                "@typescript-eslint/scope-manager": "8.62.0",
+                "@typescript-eslint/types": "8.62.0",
+                "@typescript-eslint/typescript-estree": "8.62.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2475,13 +2475,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.4.tgz",
-            "integrity": "sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
+            "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.4",
+                "@typescript-eslint/types": "8.62.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -4752,14 +4752,14 @@
             }
         },
         "node_modules/eslint-plugin-prettier": {
-            "version": "5.5.5",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
-            "integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
+            "version": "5.5.6",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.6.tgz",
+            "integrity": "sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "prettier-linter-helpers": "^1.0.1",
-                "synckit": "^0.11.12"
+                "synckit": "^0.11.13"
             },
             "engines": {
                 "node": "^14.18.0 || >=16.0.0"
@@ -8040,9 +8040,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.8.3",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-            "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+            "version": "3.9.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.1.tgz",
+            "integrity": "sha512-ppiDo2CSwexck1eyZUwJHg/N3nf1+6IRCv7W/VJ5vaLnVCmB7+3CdRfMwoCHBBX6xTrREDTksZ4OZl5SSf4zXA==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -8960,9 +8960,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -9514,13 +9514,13 @@
             }
         },
         "node_modules/synckit": {
-            "version": "0.11.12",
-            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
-            "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+            "version": "0.11.13",
+            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+            "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@pkgr/core": "^0.2.9"
+                "@pkgr/core": "^0.3.6"
             },
             "engines": {
                 "node": "^14.18.0 || >=16.0.0"
@@ -9928,16 +9928,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.59.4",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.4.tgz",
-            "integrity": "sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.0.tgz",
+            "integrity": "sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.59.4",
-                "@typescript-eslint/parser": "8.59.4",
-                "@typescript-eslint/typescript-estree": "8.59.4",
-                "@typescript-eslint/utils": "8.59.4"
+                "@typescript-eslint/eslint-plugin": "8.62.0",
+                "@typescript-eslint/parser": "8.62.0",
+                "@typescript-eslint/typescript-estree": "8.62.0",
+                "@typescript-eslint/utils": "8.62.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "@actions/core": "^2.0.3",
         "@actions/exec": "^2.0.0",
         "@actions/github": "^6.0.1",
-        "semver": "^7.8.1"
+        "semver": "^7.8.5"
     },
     "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -84,14 +84,14 @@
         "eslint-plugin-github": "^6.0.0",
         "eslint-plugin-jest": "^29.15.2",
         "eslint-plugin-jsonc": "^2.21.1",
-        "eslint-plugin-prettier": "^5.5.5",
+        "eslint-plugin-prettier": "^5.5.6",
         "globals": "^16.5.0",
         "jest": "^30.4.2",
         "make-coverage-badge": "^1.2.0",
-        "prettier": "^3.8.3",
+        "prettier": "^3.8.4",
         "prettier-eslint": "^16.4.2",
         "ts-jest": "^29.4.11",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.59.4"
+        "typescript-eslint": "^8.61.1"
     }
 }


### PR DESCRIPTION
## Summary
Update Node dependencies to their latest minor/patch versions for the monthly release.

## Changes
- `semver`: ^7.8.1 → ^7.8.5
- `eslint-plugin-prettier`: ^5.5.5 → ^5.5.6
- `prettier`: ^3.8.3 → ^3.8.4
- `typescript-eslint`: ^8.59.4 → ^8.61.1

## Skipped (major version bumps)
- @actions/artifact, @actions/core, @actions/exec, @actions/github
- @eslint/js, eslint, typescript, @vercel/ncc, globals
- eslint-plugin-jsonc, prettier-eslint, @types/node

## Test Results
- ✅ Build successful
- ✅ 107/107 tests passing
- ✅ 100% code coverage
- ✅ Linter clean