### PR TITLE
CHANGE @W-22462048@ Update Node dependencies (minor/patch versions)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,18 +22,18 @@
                 "@types/semver": "^7.7.1",
                 "@vercel/ncc": "^0.38.4",
                 "eslint": "^9.39.4",
-                "eslint-plugin-github": "^6.0.0",
-                "eslint-plugin-jest": "^29.15.2",
+                "eslint-plugin-github": "^6.1.1",
+                "eslint-plugin-jest": "^29.15.5",
                 "eslint-plugin-jsonc": "^2.21.1",
                 "eslint-plugin-prettier": "^5.5.6",
                 "globals": "^16.5.0",
                 "jest": "^30.4.2",
                 "make-coverage-badge": "^1.2.0",
-                "prettier": "^3.8.4",
+                "prettier": "^3.9.6",
                 "prettier-eslint": "^16.4.2",
-                "ts-jest": "^29.4.11",
+                "ts-jest": "^29.4.12",
                 "typescript": "^5.9.3",
-                "typescript-eslint": "^8.61.1"
+                "typescript-eslint": "^8.65.0"
             },
             "engines": {
                 "node": ">=24.0.0"
@@ -954,24 +954,37 @@
             }
         },
         "node_modules/@eslint/compat": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.4.1.tgz",
-            "integrity": "sha512-cfO82V9zxxGBxcQDr1lfaYB7wykTa0b00mGa36FrJl7iTFd0Z2cHfEYuxcBRP/iNijCsWsEkA+jzT8hGYmv33w==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.1.0.tgz",
+            "integrity": "sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^0.17.0"
+                "@eslint/core": "^1.2.1"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             },
             "peerDependencies": {
-                "eslint": "^8.40 || 9"
+                "eslint": "^8.40 || 9 || 10"
             },
             "peerDependenciesMeta": {
                 "eslint": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@eslint/compat/node_modules/@eslint/core": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+            "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@types/json-schema": "^7.0.15"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             }
         },
         "node_modules/@eslint/config-array": {
@@ -2224,17 +2237,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
-            "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+            "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.62.0",
-                "@typescript-eslint/type-utils": "8.62.0",
-                "@typescript-eslint/utils": "8.62.0",
-                "@typescript-eslint/visitor-keys": "8.62.0",
+                "@typescript-eslint/scope-manager": "8.65.0",
+                "@typescript-eslint/type-utils": "8.65.0",
+                "@typescript-eslint/utils": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -2247,7 +2260,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.62.0",
+                "@typescript-eslint/parser": "^8.65.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
@@ -2263,16 +2276,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
-            "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+            "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.62.0",
-                "@typescript-eslint/types": "8.62.0",
-                "@typescript-eslint/typescript-estree": "8.62.0",
-                "@typescript-eslint/visitor-keys": "8.62.0",
+                "@typescript-eslint/scope-manager": "8.65.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -2288,14 +2301,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
-            "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+            "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.62.0",
-                "@typescript-eslint/types": "^8.62.0",
+                "@typescript-eslint/tsconfig-utils": "^8.65.0",
+                "@typescript-eslint/types": "^8.65.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -2310,14 +2323,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
-            "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+            "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.62.0",
-                "@typescript-eslint/visitor-keys": "8.62.0"
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2328,9 +2341,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
-            "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+            "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2345,15 +2358,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
-            "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+            "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.62.0",
-                "@typescript-eslint/typescript-estree": "8.62.0",
-                "@typescript-eslint/utils": "8.62.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0",
+                "@typescript-eslint/utils": "8.65.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -2370,9 +2383,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
-            "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+            "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2384,16 +2397,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
-            "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+            "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.62.0",
-                "@typescript-eslint/tsconfig-utils": "8.62.0",
-                "@typescript-eslint/types": "8.62.0",
-                "@typescript-eslint/visitor-keys": "8.62.0",
+                "@typescript-eslint/project-service": "8.65.0",
+                "@typescript-eslint/tsconfig-utils": "8.65.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -2451,16 +2464,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
-            "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+            "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.62.0",
-                "@typescript-eslint/types": "8.62.0",
-                "@typescript-eslint/typescript-estree": "8.62.0"
+                "@typescript-eslint/scope-manager": "8.65.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2475,13 +2488,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
-            "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+            "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.62.0",
+                "@typescript-eslint/types": "8.65.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -4553,13 +4566,13 @@
             }
         },
         "node_modules/eslint-plugin-github": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-6.0.0.tgz",
-            "integrity": "sha512-J8MvUoiR/TU/Y9NnEmg1AnbvMUj9R6IO260z47zymMLLvso7B4c80IKjd8diqmqtSmeXXlbIus4i0SvK84flag==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-6.1.1.tgz",
+            "integrity": "sha512-xCqu1S/s/CCvoRLafaXNvwiVrxhroNOFLGyG9Dhi4i1PWZgPHlipjXysH6wccPFQyhSKE7gAjSLqdSdM204bZQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint/compat": "^1.2.3",
+                "@eslint/compat": "^2.0.0",
                 "@eslint/eslintrc": "^3.1.0",
                 "@eslint/js": "^9.14.0",
                 "@github/browserslist-config": "^1.0.0",
@@ -4576,18 +4589,45 @@
                 "eslint-plugin-no-only-tests": "^3.0.0",
                 "eslint-plugin-prettier": "^5.2.1",
                 "eslint-rule-documentation": ">=1.0.0",
-                "globals": "^16.0.0",
+                "globals": "^17.7.0",
                 "jsx-ast-utils": "^3.3.2",
                 "prettier": "^3.0.0",
                 "svg-element-attributes": "^1.3.1",
-                "typescript": "^5.7.3",
+                "typescript": "^6.0.3",
                 "typescript-eslint": "^8.14.0"
             },
             "bin": {
                 "eslint-ignore-errors": "bin/eslint-ignore-errors.js"
             },
             "peerDependencies": {
-                "eslint": "^8 || ^9"
+                "eslint": "^8 || ^9 || ^10"
+            }
+        },
+        "node_modules/eslint-plugin-github/node_modules/globals": {
+            "version": "17.7.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+            "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint-plugin-github/node_modules/typescript": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
             }
         },
         "node_modules/eslint-plugin-i18n-text": {
@@ -4655,9 +4695,9 @@
             }
         },
         "node_modules/eslint-plugin-jest": {
-            "version": "29.15.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.2.tgz",
-            "integrity": "sha512-kEN4r9RZl1xcsb4arGq89LrcVdOUFII/JSCwtTPJyv16mDwmPrcuEQwpxqZHeINvcsd7oK5O/rhdGlxFRaZwvQ==",
+            "version": "29.15.5",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.5.tgz",
+            "integrity": "sha512-gnY9aw4HO7bI6lnKf+tx9uX/dwDPX5tHK3MB5Jd/NmmOHwEY8H8Caf2a39DNCZoqJ+j8EqNra/iuoj/z3GuAeA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4670,7 +4710,7 @@
                 "@typescript-eslint/eslint-plugin": "^8.0.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "jest": "*",
-                "typescript": ">=4.8.4 <7.0.0"
+                "typescript": ">=4.8.4 <8.0.0"
             },
             "peerDependenciesMeta": {
                 "@typescript-eslint/eslint-plugin": {
@@ -8040,9 +8080,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.1.tgz",
-            "integrity": "sha512-ppiDo2CSwexck1eyZUwJHg/N3nf1+6IRCv7W/VJ5vaLnVCmB7+3CdRfMwoCHBBX6xTrREDTksZ4OZl5SSf4zXA==",
+            "version": "3.9.6",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+            "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -9684,9 +9724,9 @@
             }
         },
         "node_modules/ts-jest": {
-            "version": "29.4.11",
-            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
-            "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
+            "version": "29.4.12",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.12.tgz",
+            "integrity": "sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9696,7 +9736,7 @@
                 "json5": "^2.2.3",
                 "lodash.memoize": "^4.1.2",
                 "make-error": "^1.3.6",
-                "semver": "^7.8.0",
+                "semver": "^7.8.5",
                 "type-fest": "^4.41.0",
                 "yargs-parser": "^21.1.1"
             },
@@ -9928,16 +9968,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.62.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.0.tgz",
-            "integrity": "sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+            "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.62.0",
-                "@typescript-eslint/parser": "8.62.0",
-                "@typescript-eslint/typescript-estree": "8.62.0",
-                "@typescript-eslint/utils": "8.62.0"
+                "@typescript-eslint/eslint-plugin": "8.65.0",
+                "@typescript-eslint/parser": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0",
+                "@typescript-eslint/utils": "8.65.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -81,17 +81,17 @@
         "@types/semver": "^7.7.1",
         "@vercel/ncc": "^0.38.4",
         "eslint": "^9.39.4",
-        "eslint-plugin-github": "^6.0.0",
-        "eslint-plugin-jest": "^29.15.2",
+        "eslint-plugin-github": "^6.1.1",
+        "eslint-plugin-jest": "^29.15.5",
         "eslint-plugin-jsonc": "^2.21.1",
         "eslint-plugin-prettier": "^5.5.6",
         "globals": "^16.5.0",
         "jest": "^30.4.2",
         "make-coverage-badge": "^1.2.0",
-        "prettier": "^3.8.4",
+        "prettier": "^3.9.6",
         "prettier-eslint": "^16.4.2",
-        "ts-jest": "^29.4.11",
+        "ts-jest": "^29.4.12",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.61.1"
+        "typescript-eslint": "^8.65.0"
     }
 }


### PR DESCRIPTION
## Summary
Monthly refresh of Node dev dependencies for the run-code-analyzer GitHub Action (minor/patch only).

## Updated (minor/patch)
- eslint-plugin-github: 6.0.0 → 6.1.1
- eslint-plugin-jest: 29.15.2 → 29.15.5
- prettier: 3.8.4 → 3.9.6
- ts-jest: 29.4.11 → 29.4.12
- typescript-eslint: 8.61.1 → 8.65.0

## Skipped (major version bumps — not updated)
- @actions/artifact (5→6), @actions/core (2→3), @actions/exec (2→3), @actions/github (6→9)
- eslint / @eslint/js (9→10), typescript (5→7)
- eslint-plugin-jsonc (2→3), globals (16→17), prettier-eslint (16→17)
- @types/node (keep v22), @vercel/ncc (0.38→0.44)

## Test Results
- ✅ Lint clean
- ✅ All tests passing (107/107, 100% coverage)
- ✅ Bundled dist/ unchanged (only dev deps updated)

## Notes
Only dev dependencies changed; runtime deps (@actions/*, semver) untouched, so the committed dist/ bundle is unaffected.