### PR TITLE
CHANGE @W-22462053@ Update Node dependencies (minor/patch versions)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,11 +19,11 @@
                 "@eslint/js": "^9.39.4",
                 "@types/jest": "^30.0.0",
                 "@types/node": "^22.19.19",
-                "@types/semver": "^7.7.1",
+                "@types/semver": "^7.8.0",
                 "@vercel/ncc": "^0.38.4",
                 "eslint": "^9.39.4",
-                "eslint-plugin-github": "^6.1.1",
-                "eslint-plugin-jest": "^29.15.5",
+                "eslint-plugin-github": "^6.1.2",
+                "eslint-plugin-jest": "^29.16.2",
                 "eslint-plugin-jsonc": "^2.21.1",
                 "eslint-plugin-prettier": "^5.5.6",
                 "globals": "^16.5.0",
@@ -33,7 +33,7 @@
                 "prettier-eslint": "^16.4.2",
                 "ts-jest": "^29.4.12",
                 "typescript": "^5.9.3",
-                "typescript-eslint": "^8.65.0"
+                "typescript-eslint": "^8.68.0"
             },
             "engines": {
                 "node": ">=24.0.0"
@@ -1029,9 +1029,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "3.3.5",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-            "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+            "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1041,7 +1041,7 @@
                 "globals": "^14.0.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
-                "js-yaml": "^4.1.1",
+                "js-yaml": "^4.3.0",
                 "minimatch": "^3.1.5",
                 "strip-json-comments": "^3.1.1"
             },
@@ -2206,9 +2206,9 @@
             }
         },
         "node_modules/@types/semver": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
-            "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
+            "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -2237,17 +2237,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
-            "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.68.0.tgz",
+            "integrity": "sha512-WASHDpCm6qO5jj9g1a+8NiW5+GCkAyLReR56/4VruYmNgfUmqpxOfZ2Yfb8xGfJPWv5Qi6LSD8sXdces3vbp/Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.65.0",
-                "@typescript-eslint/type-utils": "8.65.0",
-                "@typescript-eslint/utils": "8.65.0",
-                "@typescript-eslint/visitor-keys": "8.65.0",
+                "@typescript-eslint/scope-manager": "8.68.0",
+                "@typescript-eslint/type-utils": "8.68.0",
+                "@typescript-eslint/utils": "8.68.0",
+                "@typescript-eslint/visitor-keys": "8.68.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -2260,7 +2260,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.65.0",
+                "@typescript-eslint/parser": "^8.68.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
@@ -2276,16 +2276,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
-            "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.68.0.tgz",
+            "integrity": "sha512-fHq2VC1kpyYfvEcbiMjOpySY4WS7voEp89yAThrHRX5sm9j2lzYppCb2umFMEed4fWcyeLjHxrz0mpjNBaBxMQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.65.0",
-                "@typescript-eslint/types": "8.65.0",
-                "@typescript-eslint/typescript-estree": "8.65.0",
-                "@typescript-eslint/visitor-keys": "8.65.0",
+                "@typescript-eslint/scope-manager": "8.68.0",
+                "@typescript-eslint/types": "8.68.0",
+                "@typescript-eslint/typescript-estree": "8.68.0",
+                "@typescript-eslint/visitor-keys": "8.68.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -2301,14 +2301,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
-            "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.68.0.tgz",
+            "integrity": "sha512-5GQtWZCXFcFYux955pvoS02WLc49pXNlvIxocKjS0clvwo3in1RdlzVKyiqQH9vE5AKWFLTaUgeQkOrTS+0Qxw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.65.0",
-                "@typescript-eslint/types": "^8.65.0",
+                "@typescript-eslint/tsconfig-utils": "^8.68.0",
+                "@typescript-eslint/types": "^8.68.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -2323,14 +2323,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
-            "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.68.0.tgz",
+            "integrity": "sha512-T5eXpcaJNg8bhjHJ8Rjp68Vq/QBteYtTKY8TZqVNPaUbuz0f6jI9t6aDkylwvalpAB9XTTFeFOjrjXAZ3YvmVA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.65.0",
-                "@typescript-eslint/visitor-keys": "8.65.0"
+                "@typescript-eslint/types": "8.68.0",
+                "@typescript-eslint/visitor-keys": "8.68.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2341,9 +2341,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
-            "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.68.0.tgz",
+            "integrity": "sha512-F7zrGQfiJHojPwi8vhxZQC1tWtJzvL74cK/nqri2lk8YUXvYaYwl263xOJ69jDWPUk1hmcdoayFwk9lX09npVw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2358,15 +2358,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
-            "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.68.0.tgz",
+            "integrity": "sha512-X77zqoY1EjeWGs/0JNxeaMfp5C5lIz4Tw8y66F1Ne8Faq6g424sBNYM6xBAqElfGZPLpWS+CZAp0DXyKDzWiHg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.65.0",
-                "@typescript-eslint/typescript-estree": "8.65.0",
-                "@typescript-eslint/utils": "8.65.0",
+                "@typescript-eslint/types": "8.68.0",
+                "@typescript-eslint/typescript-estree": "8.68.0",
+                "@typescript-eslint/utils": "8.68.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -2383,9 +2383,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
-            "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.68.0.tgz",
+            "integrity": "sha512-9RnpsGJjrAllCMefGVVsImJM24YurhC0Q1h4UbvivtvOqXmR/vEJge2OoE++z9m6hyg8T1Q8t5SNT6tHSbrxcg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2397,16 +2397,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
-            "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.68.0.tgz",
+            "integrity": "sha512-OKKsD0tYmoNiU5PW2zehO1yO56jYOm1ShYlxon/Z0SJNidAkdVg86eg9ruRuoXf8xfnuWZGbwDsStkoXbZtIIA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.65.0",
-                "@typescript-eslint/tsconfig-utils": "8.65.0",
-                "@typescript-eslint/types": "8.65.0",
-                "@typescript-eslint/visitor-keys": "8.65.0",
+                "@typescript-eslint/project-service": "8.68.0",
+                "@typescript-eslint/tsconfig-utils": "8.68.0",
+                "@typescript-eslint/types": "8.68.0",
+                "@typescript-eslint/visitor-keys": "8.68.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -2435,26 +2435,26 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "version": "10.2.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+            "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.5"
+                "brace-expansion": "^5.0.8"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -2464,16 +2464,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
-            "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.68.0.tgz",
+            "integrity": "sha512-PB5gJMMOg0Q5P1tsgWtEAqQacJXq0qEqRHDX/YJ4FaTMLfZPpHB3gjl2EJuiZyPABxmj4ZQYiY9m1bdAJ5y7tQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.65.0",
-                "@typescript-eslint/types": "8.65.0",
-                "@typescript-eslint/typescript-estree": "8.65.0"
+                "@typescript-eslint/scope-manager": "8.68.0",
+                "@typescript-eslint/types": "8.68.0",
+                "@typescript-eslint/typescript-estree": "8.68.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2488,13 +2488,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
-            "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.68.0.tgz",
+            "integrity": "sha512-YR65gGdGvTUAWLldC3xLOvOzamdGzB4A5/N8rehEaHs3Zvoe39BhgY+u0SPch1OvrVTfLcc55wsSgK2NcnTS/A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/types": "8.68.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -4566,15 +4566,15 @@
             }
         },
         "node_modules/eslint-plugin-github": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-6.1.1.tgz",
-            "integrity": "sha512-xCqu1S/s/CCvoRLafaXNvwiVrxhroNOFLGyG9Dhi4i1PWZgPHlipjXysH6wccPFQyhSKE7gAjSLqdSdM204bZQ==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-6.1.2.tgz",
+            "integrity": "sha512-XU1fVItfnwYWXG0GqH0MV2VY9EzvgbPxDnUJ9I1915Cpn24z13Vgx1pttrdQy6bhLmDYp+Wl7pX/L1YMKdG+6g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint/compat": "^2.0.0",
-                "@eslint/eslintrc": "^3.1.0",
-                "@eslint/js": "^9.14.0",
+                "@eslint/eslintrc": "^3.3.6",
+                "@eslint/js": "^9.39.5",
                 "@github/browserslist-config": "^1.0.0",
                 "@typescript-eslint/eslint-plugin": "^8.0.0",
                 "@typescript-eslint/parser": "^8.0.0",
@@ -4601,6 +4601,19 @@
             },
             "peerDependencies": {
                 "eslint": "^8 || ^9 || ^10"
+            }
+        },
+        "node_modules/eslint-plugin-github/node_modules/@eslint/js": {
+            "version": "9.39.5",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+            "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
             }
         },
         "node_modules/eslint-plugin-github/node_modules/globals": {
@@ -4695,9 +4708,9 @@
             }
         },
         "node_modules/eslint-plugin-jest": {
-            "version": "29.15.5",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.5.tgz",
-            "integrity": "sha512-gnY9aw4HO7bI6lnKf+tx9uX/dwDPX5tHK3MB5Jd/NmmOHwEY8H8Caf2a39DNCZoqJ+j8EqNra/iuoj/z3GuAeA==",
+            "version": "29.16.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.16.2.tgz",
+            "integrity": "sha512-vDIaCZzzyQNqwvECtPaN3hMd5wPVMKlK5P9C8WOgO9oDKmIEvRN8uSNb1BctKG0N/DVJUvEnTm5xB2yS21oKZg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7012,10 +7025,20 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -9968,16 +9991,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
-            "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
+            "version": "8.68.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.68.0.tgz",
+            "integrity": "sha512-MHy0Y0ynqeEbx/S45+i/bBssdy3X6KNBfmJAP35GrgtNxu2TQ5K5xsFDhAnmsq1jvpdoZOPG1LGtJo0HWqYCrQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.65.0",
-                "@typescript-eslint/parser": "8.65.0",
-                "@typescript-eslint/typescript-estree": "8.65.0",
-                "@typescript-eslint/utils": "8.65.0"
+                "@typescript-eslint/eslint-plugin": "8.68.0",
+                "@typescript-eslint/parser": "8.68.0",
+                "@typescript-eslint/typescript-estree": "8.68.0",
+                "@typescript-eslint/utils": "8.68.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -78,11 +78,11 @@
         "@eslint/js": "^9.39.4",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.19.19",
-        "@types/semver": "^7.7.1",
+        "@types/semver": "^7.8.0",
         "@vercel/ncc": "^0.38.4",
         "eslint": "^9.39.4",
-        "eslint-plugin-github": "^6.1.1",
-        "eslint-plugin-jest": "^29.15.5",
+        "eslint-plugin-github": "^6.1.2",
+        "eslint-plugin-jest": "^29.16.2",
         "eslint-plugin-jsonc": "^2.21.1",
         "eslint-plugin-prettier": "^5.5.6",
         "globals": "^16.5.0",
@@ -92,6 +92,6 @@
         "prettier-eslint": "^16.4.2",
         "ts-jest": "^29.4.12",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.65.0"
+        "typescript-eslint": "^8.68.0"
     }
 }


### PR DESCRIPTION
## Summary
Monthly release dependency refresh for the run-code-analyzer GitHub Action. Updates dev dependencies to their latest minor/patch versions; major (breaking) updates are intentionally skipped, consistent with prior monthly dependency PRs (#133, #135).

### Updated (minor/patch)
- `@types/semver`: 7.7.1 → 7.8.0
- `eslint-plugin-github`: 6.1.1 → 6.1.2
- `eslint-plugin-jest`: 29.15.5 → 29.16.2
- `typescript-eslint`: 8.65.0 → 8.68.0

### Skipped (major / breaking)
- `@actions/artifact` v6, `@actions/core` v3, `@actions/exec` v3, `@actions/github` v9
- `@eslint/js` v10, `eslint` v10, `@types/node` v26, `typescript` v7
- `eslint-plugin-jsonc` v3, `globals` v17, `prettier-eslint` v17, `@vercel/ncc` (0.x)

## Test Plan
- [x] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] `npm test` — 107 tests passing, 100% coverage
- [x] `npm run build` (ncc) — `dist/` regenerated; byte-identical (only devDependencies changed)